### PR TITLE
cmake: add more input validation checks to function flatcc_generate_s…

### DIFF
--- a/cmake/FlatccGenerateSources.cmake
+++ b/cmake/FlatccGenerateSources.cmake
@@ -3,7 +3,7 @@
 # as a dependency or adds the generated sources.
 #
 #   flatcc_generate_sources(
-#      <name>
+#      TARGET_NAME <name>
 #      DEFINITION_FILES <flatbuffer-definition-file> [<flatbuffer-definition-file> [...]]
 #      [OUTPUT_DIR <output-directory>]
 #      [ALL] [SCHEMA] [COMMON] [COMMON_READER] [COMMON_BUILDER] [BUILDER] [READER]
@@ -90,15 +90,28 @@ cmake_minimum_required(VERSION 3.3)
 # TODO: not needed when cmake_minimum_required_version >= 3.4
 include(CMakeParseArguments)
 
-function(flatcc_generate_sources NAME)
+function(flatcc_generate_sources)
     # parse function arguments
     set(output_options SCHEMA COMMON COMMON_READER COMMON_BUILDER BUILDER READER VERIFIER JSON_PARSER JSON_PRINTER JSON)
     set(NO_VAL_ARGS ALL RECURSIVE ${output_options})
-    set(SINGLE_VAL_ARGS OUTPUT_DIR OUTFILE PREFIX TARGET)
+    set(SINGLE_VAL_ARGS TARGET_NAME OUTPUT_DIR OUTFILE PREFIX TARGET)
     set(MULTI_VAL_ARGS DEFINITION_FILES COMPILE_FLAGS PATHS)
 
     cmake_parse_arguments(FLATCC "${NO_VAL_ARGS}" "${SINGLE_VAL_ARGS}" "${MULTI_VAL_ARGS}" ${ARGN})
+    
+    # TODO: add following check when cmake_minimum_required_version >= 3.15
+    #if (FLATCC_KEYWORDS_MISSING_VALUES)
+    #    message(FATAL_ERROR "The following keywords in call to flatcc_generate_sources have no value: ${FLATCC_KEYWORDS_MISSING_VALUES}")
+    #endif()
 
+    if (FLATCC_UNPARSED_ARGUMENTS)
+        message(WARNING "The following unknown keywords in call to flatcc_generate_sources are ignored: ${FLATCC_UNPARSED_ARGUMENTS}")
+    endif()
+
+    if (NOT FLATCC_TARGET_NAME)
+        message(FATAL_ERROR "TARGET_NAME not provided in call to flatcc_generate_sources")
+    endif()
+    
     if (NOT FLATCC_DEFINITION_FILES)
         message(FATAL_ERROR "No flatbuffer definition files provided")
     endif()
@@ -317,13 +330,13 @@ function(flatcc_generate_sources NAME)
         DEPENDS flatcc::cli ${ABSOLUTE_DEFINITIONS_DEPENDENCIES}
     )
 
-    add_custom_target("flatcc_generated_${NAME}"
+    add_custom_target("flatcc_generated_${FLATCC_TARGET_NAME}"
         DEPENDS ${OUTPUT_FILES})
 
-    add_library("__flatcc_generated_${NAME}" INTERFACE)
-    target_include_directories("__flatcc_generated_${NAME}" INTERFACE "${FLATCC_OUTPUT_DIR}")
-    add_dependencies("__flatcc_generated_${NAME}" "flatcc_generated_${NAME}")
+    add_library("__flatcc_generated_${FLATCC_TARGET_NAME}" INTERFACE)
+    target_include_directories("__flatcc_generated_${FLATCC_TARGET_NAME}" INTERFACE "${FLATCC_OUTPUT_DIR}")
+    add_dependencies("__flatcc_generated_${FLATCC_TARGET_NAME}" "flatcc_generated_${FLATCC_TARGET_NAME}")
 
-    add_library("flatcc_generated::${NAME}" ALIAS "__flatcc_generated_${NAME}")
-    set("${NAME}_GENERATED_SOURCES" ${OUTPUT_FILES} PARENT_SCOPE)
+    add_library("flatcc_generated::${FLATCC_TARGET_NAME}" ALIAS "__flatcc_generated_${FLATCC_TARGET_NAME}")
+    set("${FLATCC_TARGET_NAME}_GENERATED_SOURCES" ${OUTPUT_FILES} PARENT_SCOPE)
 endfunction()

--- a/cmake/FlatccGenerateSources.cmake
+++ b/cmake/FlatccGenerateSources.cmake
@@ -3,7 +3,7 @@
 # as a dependency or adds the generated sources.
 #
 #   flatcc_generate_sources(
-#      TARGET_NAME <name>
+#      OUTPUT_NAME <name>
 #      DEFINITION_FILES <flatbuffer-definition-file> [<flatbuffer-definition-file> [...]]
 #      [OUTPUT_DIR <output-directory>]
 #      [ALL] [SCHEMA] [COMMON] [COMMON_READER] [COMMON_BUILDER] [BUILDER] [READER]
@@ -28,7 +28,7 @@
 #
 # Required arguments:
 #
-#   <name>
+#   OUTPUT_NAME <name>
 #
 #     Unique name. It is used for output variable(s) and target(s).
 #
@@ -94,7 +94,7 @@ function(flatcc_generate_sources)
     # parse function arguments
     set(output_options SCHEMA COMMON COMMON_READER COMMON_BUILDER BUILDER READER VERIFIER JSON_PARSER JSON_PRINTER JSON)
     set(NO_VAL_ARGS ALL RECURSIVE ${output_options})
-    set(SINGLE_VAL_ARGS TARGET_NAME OUTPUT_DIR OUTFILE PREFIX TARGET)
+    set(SINGLE_VAL_ARGS OUTPUT_NAME OUTPUT_DIR OUTFILE PREFIX TARGET)
     set(MULTI_VAL_ARGS DEFINITION_FILES COMPILE_FLAGS PATHS)
 
     cmake_parse_arguments(FLATCC "${NO_VAL_ARGS}" "${SINGLE_VAL_ARGS}" "${MULTI_VAL_ARGS}" ${ARGN})
@@ -108,8 +108,8 @@ function(flatcc_generate_sources)
         message(WARNING "The following unknown keywords in call to flatcc_generate_sources are ignored: ${FLATCC_UNPARSED_ARGUMENTS}")
     endif()
 
-    if (NOT FLATCC_TARGET_NAME)
-        message(FATAL_ERROR "TARGET_NAME not provided in call to flatcc_generate_sources")
+    if (NOT FLATCC_OUTPUT_NAME)
+        message(FATAL_ERROR "OUTPUT_NAME not provided in call to flatcc_generate_sources")
     endif()
     
     if (NOT FLATCC_DEFINITION_FILES)
@@ -330,13 +330,13 @@ function(flatcc_generate_sources)
         DEPENDS flatcc::cli ${ABSOLUTE_DEFINITIONS_DEPENDENCIES}
     )
 
-    add_custom_target("flatcc_generated_${FLATCC_TARGET_NAME}"
+    add_custom_target("flatcc_generated_${FLATCC_OUTPUT_NAME}"
         DEPENDS ${OUTPUT_FILES})
 
-    add_library("__flatcc_generated_${FLATCC_TARGET_NAME}" INTERFACE)
-    target_include_directories("__flatcc_generated_${FLATCC_TARGET_NAME}" INTERFACE "${FLATCC_OUTPUT_DIR}")
-    add_dependencies("__flatcc_generated_${FLATCC_TARGET_NAME}" "flatcc_generated_${FLATCC_TARGET_NAME}")
+    add_library("__flatcc_generated_${FLATCC_OUTPUT_NAME}" INTERFACE)
+    target_include_directories("__flatcc_generated_${FLATCC_OUTPUT_NAME}" INTERFACE "${FLATCC_OUTPUT_DIR}")
+    add_dependencies("__flatcc_generated_${FLATCC_OUTPUT_NAME}" "flatcc_generated_${FLATCC_OUTPUT_NAME}")
 
-    add_library("flatcc_generated::${FLATCC_TARGET_NAME}" ALIAS "__flatcc_generated_${FLATCC_TARGET_NAME}")
-    set("${FLATCC_TARGET_NAME}_GENERATED_SOURCES" ${OUTPUT_FILES} PARENT_SCOPE)
+    add_library("flatcc_generated::${FLATCC_OUTPUT_NAME}" ALIAS "__flatcc_generated_${FLATCC_OUTPUT_NAME}")
+    set("${FLATCC_OUTPUT_NAME}_GENERATED_SOURCES" ${OUTPUT_FILES} PARENT_SCOPE)
 endfunction()

--- a/cmake/FlatccGenerateSources.cmake
+++ b/cmake/FlatccGenerateSources.cmake
@@ -72,10 +72,6 @@
 #
 #     Prefix all symbols with `prefix`
 #
-#   TARGET <target>
-#
-#     Create a custom target named `target` that will generate the sources.
-#
 #   PATHS <include-path> [<include-path> [...]]
 #
 #     Add extra include search paths where flatcc should look for included defintion files.
@@ -94,7 +90,7 @@ function(flatcc_generate_sources)
     # parse function arguments
     set(output_options SCHEMA COMMON COMMON_READER COMMON_BUILDER BUILDER READER VERIFIER JSON_PARSER JSON_PRINTER JSON)
     set(NO_VAL_ARGS ALL RECURSIVE ${output_options})
-    set(SINGLE_VAL_ARGS OUTPUT_NAME OUTPUT_DIR OUTFILE PREFIX TARGET)
+    set(SINGLE_VAL_ARGS OUTPUT_NAME OUTPUT_DIR OUTFILE PREFIX)
     set(MULTI_VAL_ARGS DEFINITION_FILES COMPILE_FLAGS PATHS)
 
     cmake_parse_arguments(FLATCC "${NO_VAL_ARGS}" "${SINGLE_VAL_ARGS}" "${MULTI_VAL_ARGS}" ${ARGN})


### PR DESCRIPTION
Add some more input validation checks to the flatcc_generate_sources function.
Instead of taking the output target name as a function argument I added it to the single value arguments with keyword TARGET_NAME because that makes input validation a lot easier.